### PR TITLE
added support for custom OAuth2 application

### DIFF
--- a/src/LuKaSo.Zonky/Api/ZonkyApi.cs
+++ b/src/LuKaSo.Zonky/Api/ZonkyApi.cs
@@ -21,7 +21,7 @@ namespace LuKaSo.Zonky.Api
         /// <summary>
         /// OAuth preshared secret
         /// </summary>
-        private const string _oAuth2Secret = "d2ViOndlYg==";
+        private readonly string _oAuth2Secret;
 
         /// <summary>
         /// Used HTTP client
@@ -49,7 +49,7 @@ namespace LuKaSo.Zonky.Api
         /// Zonky API constructor with default production address of service
         /// </summary>
         /// <param name="httpClient">HTTP client</param>
-        public ZonkyApi(HttpClient httpClient) : this(new Uri("https://api.zonky.cz/"), httpClient)
+        public ZonkyApi(string oAuth2Secret, HttpClient httpClient) : this(new Uri("https://api.zonky.cz/"), oAuth2Secret, httpClient)
         {
         }
 
@@ -58,7 +58,7 @@ namespace LuKaSo.Zonky.Api
         /// </summary>
         /// <param name="baseUrl">Base URL of service</param>
         /// <param name="httpClient">HTTP client</param>
-        public ZonkyApi(Uri baseUrl, HttpClient httpClient) : this(baseUrl, httpClient, new ZonkyResponseResolverFactory())
+        public ZonkyApi(Uri baseUrl, string oauth2Secret, HttpClient httpClient) : this(baseUrl, oauth2Secret, httpClient, new ZonkyResponseResolverFactory())
         {
         }
 
@@ -68,9 +68,10 @@ namespace LuKaSo.Zonky.Api
         /// <param name="baseUrl">Base URL of service</param>
         /// <param name="httpClient">HTTP client</param>
         /// <param name="resolverFactory">Resolver factory</param>
-        internal ZonkyApi(Uri baseUrl, HttpClient httpClient, ZonkyResponseResolverFactory resolverFactory)
+        internal ZonkyApi(Uri baseUrl, string oauth2Secret, HttpClient httpClient, ZonkyResponseResolverFactory resolverFactory)
         {
             _httpClient = httpClient;
+            _oAuth2Secret = oauth2Secret;
             _baseUrl = baseUrl;
             _settings = new Lazy<JsonSerializerSettings>(() =>
             {

--- a/src/LuKaSo.Zonky/Client/ZonkyClient.cs
+++ b/src/LuKaSo.Zonky/Client/ZonkyClient.cs
@@ -106,7 +106,8 @@ namespace LuKaSo.Zonky.Client
         /// </summary>
         /// <param name="user">User</param>
         /// <param name="enableTrading">Enable trading</param>
-        public ZonkyClient(User user, bool enableTrading) : this(user, enableTrading, false) { }
+        /// <param name="oAuth2Secret">OAuth2 application access "appId:appSecret" encoded in base64</param>
+        public ZonkyClient(User user, bool enableTrading, string oAuth2Secret = "d2ViOndlYg==") : this(user, enableTrading, false, oAuth2Secret) { }
 
         /// <summary>
         /// Zonky client
@@ -114,9 +115,11 @@ namespace LuKaSo.Zonky.Client
         /// <param name="user">User</param>
         /// <param name="enableTrading">Enable trading</param>
         /// <param name="marketplaceRequestsAuthorized">Marketplace requests authorized</param>
-        public ZonkyClient(User user, bool enableTrading, bool marketplaceRequestsAuthorized) : this()
+        /// <param name="oAuth2Secret">OAuth2 application access "appId:appSecret" encoded in base64</param>
+        public ZonkyClient(User user, bool enableTrading, bool marketplaceRequestsAuthorized, string oAuth2Secret = "d2ViOndlYg==") : this()
         {
             _user = user ?? throw new ArgumentNullException(nameof(user));
+            _oAuth2Secret = oAuth2Secret;
             _enableTrading = enableTrading;
             _marketplaceRequestsAuthorized = marketplaceRequestsAuthorized;
 
@@ -129,7 +132,8 @@ namespace LuKaSo.Zonky.Client
         /// <param name="userName">User name</param>
         /// <param name="password">Password</param>
         /// <param name="enableTrading">Enable trading</param>
-        public ZonkyClient(string userName, string password, bool enableTrading) : this(new User(userName, password), enableTrading) { }
+        /// <param name="oAuth2Secret">OAuth2 application access "appId:appSecret" encoded in base64</param>
+        public ZonkyClient(string userName, string password, bool enableTrading, string oAuth2Secret = "d2ViOndlYg==") : this(new User(userName, password), enableTrading, oAuth2Secret) { }
 
         /// <summary>
         /// Zonky client
@@ -138,7 +142,8 @@ namespace LuKaSo.Zonky.Client
         /// <param name="password">Password</param>
         /// <param name="enableTrading">Enable trading</param>
         /// <param name="marketplaceRequestsAuthorized">Marketplace requests authorized</param>
-        public ZonkyClient(string userName, string password, bool enableTrading, bool marketplaceRequestsAuthorized) : this(new User(userName, password), enableTrading, marketplaceRequestsAuthorized) { }
+        /// <param name="oAuth2Secret">OAuth2 application access "appId:appSecret" encoded in base64</param>
+        public ZonkyClient(string userName, string password, bool enableTrading, bool marketplaceRequestsAuthorized, string oAuth2Secret = "d2ViOndlYg==") : this(new User(userName, password), enableTrading, marketplaceRequestsAuthorized, oAuth2Secret) { }
 
         /// <summary>
         /// Login

--- a/src/LuKaSo.Zonky/Client/ZonkyClient.cs
+++ b/src/LuKaSo.Zonky/Client/ZonkyClient.cs
@@ -47,6 +47,11 @@ namespace LuKaSo.Zonky.Client
         private bool _wrongPassword;
 
         /// <summary>
+        /// OAuth preshared secret
+        /// </summary>
+        private readonly string _oAuth2Secret;
+
+        /// <summary>
         /// Authorization token
         /// </summary>
         private readonly object _authorizationTokenLock = new object();
@@ -86,10 +91,12 @@ namespace LuKaSo.Zonky.Client
         /// <summary>
         /// Zonky client
         /// </summary>
-        public ZonkyClient()
+        /// <param name="oAuth2Secret">OAuth2 application access "appId:appSecret" encoded in base64</param>
+        public ZonkyClient(string oAuth2Secret = "d2ViOndlYg==")
         {
             _log = LogProvider.For<ZonkyClient>();
-            _zonkyApi = new Lazy<IZonkyApi>(() => new ZonkyApi(new HttpClient()));
+            _oAuth2Secret = oAuth2Secret;
+            _zonkyApi = new Lazy<IZonkyApi>(() => new ZonkyApi(_oAuth2Secret, new HttpClient()));
 
             _log.Debug($"Created Zonky client.");
         }

--- a/tests/LuKaSo.Zonky.Tests.IntegrationApiaryMock/Common/ZonkyApiFactory.cs
+++ b/tests/LuKaSo.Zonky.Tests.IntegrationApiaryMock/Common/ZonkyApiFactory.cs
@@ -8,7 +8,7 @@ namespace LuKaSo.Zonky.Tests.IntegrationApiaryMock.Common
     {
         public static ZonkyApi Create()
         {
-            return new ZonkyApi(new Uri("http://private-4c0953-zonky.apiary-mock.com"), new HttpClient());
+            return new ZonkyApi(new Uri("http://private-4c0953-zonky.apiary-mock.com"), "d2ViOndlYg==", new HttpClient());
         }
     }
 }


### PR DESCRIPTION
This PR adds support for custom OAuth2 application instead of hardcoded `web:web` OAuth2 app credentials

Watch out, tests will fail because Zonky changed the OAuth2 scopes - °~~will send another PR for that~~

EDIT: i will not send another PR, zonky totally fucked up the API access - they disabled the default web client and for custom clients they don't enable the password grant flow - they want from us to use the authorization code grant flow.